### PR TITLE
Use File input format for repository scans #45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- General improvements:
+  - Updated `ps-rule-assert` task to use `File` input format for repository scans. [#45](https://github.com/microsoft/PSRule-pipelines/issues/45)
+    - The `Input.PathIgnore` option can be configured to exclude files.
+    - Path specs included in `.gitignore` are also automatically excluded.
+
 ## v0.4.0
 
 What's changed since v0.3.0:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "PSRule",
+    "name": "psrule-pipelines",
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {

--- a/tasks/ps-rule-assert/powershell.ps1
+++ b/tasks/ps-rule-assert/powershell.ps1
@@ -112,7 +112,7 @@ foreach ($m in $moduleNames) {
     }
     # Check
     if ($Null -eq (Get-InstalledModule -Name $m)) {
-        Write-Host "  - Failed to install";
+        Write-Host '  - Failed to install';
     }
     else {
         Write-Host "  - Using version: $((Get-InstalledModule -Name $m).Version)";
@@ -150,13 +150,10 @@ try {
 
     # Repository
     if ($InputType -eq 'repository') {
-        $items = New-Object -TypeName System.Collections.ArrayList;
         WriteDebug 'Running ''Assert-PSRule'' with repository as input.';
-        $Null = $items.Add((Get-Item -Path $InputPath));
-        $Null = $items.AddRange((Get-ChildItem -Path $InputPath -File -Recurse));
         Write-Host '';
         Write-Host '---';
-        $items.ToArray() | Assert-PSRule @invokeParams;
+        Assert-PSRule @invokeParams -InputPath $InputPath -Format File;
     }
     # Repository
     elseif ($InputType -eq 'inputPath') {


### PR DESCRIPTION
## PR Summary

- Updated `ps-rule-assert` task to use `File` input format for repository scans. #45

Fixes #45 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
