### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.5.0
+
+What's changed since v0.4.0:
+
 - General improvements:
   - Updated `ps-rule-assert` task to use `File` input format for repository scans. [#45](https://github.com/microsoft/PSRule-pipelines/issues/45)
     - The `Input.PathIgnore` option can be configured to exclude files.


### PR DESCRIPTION
## PR Summary

What's changed since v0.4.0:

- General improvements:
  - Updated `ps-rule-assert` task to use `File` input format for repository scans. #45
    - The `Input.PathIgnore` option can be configured to exclude files.
    - Path specs included in `.gitignore` are also automatically excluded.
- Engineering:
  - Updated to PSRule v0.20.0. #54

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
