### PR TITLE
Added support for using baselines #46

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     },
     "files.associations": {
         "**/.azure-pipelines/**/*.yaml": "azure-pipelines"
-    }
+    },
+    "cSpell.words": [
+        "cmdlets"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 What's changed since v0.7.0:
 
+- General improvements:
+  - Added support for using baselines. [#46](https://github.com/microsoft/PSRule-pipelines/issues/46)
+    - Specify a named baseline by using `baseline: '<baseline_name>'`.
+    - Baselines can be included from individual files or modules using `source:` and `modules:`.
 - Engineering:
   - Bump PSRule dependency to v1.0.1. [#106](https://github.com/microsoft/PSRule-pipelines/issues/106)
     - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v101)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use these tasks within YAML pipelines:
 
 - Install rule modules with the `ps-rule-install` task (optional).
 - Run analysis one or more times with the `ps-rule-assert` task.
-- Publish analysis results with the [Publish Test Results](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml) builtin task.
+- Publish analysis results with the [Publish Test Results](https://docs.microsoft.com/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml) builtin task.
 
 For example:
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -7,7 +7,7 @@ The following pipeline tasks are included in this extension.
 Use this task to install rule modules and their dependencies.
 Modules will be installed to the current user scope.
 
-### Syntax
+Syntax:
 
 ```yaml
 steps:
@@ -42,7 +42,7 @@ steps:
 Perform analysis and assert PSRule conditions.
 Analysis can be perform from input files or the repository structure.
 
-### Syntax
+Syntax:
 
 ```yaml
 steps:
@@ -51,6 +51,7 @@ steps:
     inputType: repository, inputPath              # Required. Determines the type of input to use for PSRule.
     inputPath: string                             # Required. The path PSRule will look for files to validate.
     modules: string                               # Optional. A comma separated list of modules to use for analysis.
+    baseline: string                              # Optional. The name of a PSRule baseline to use.
     source: string                                # Optional. An path containing rules to use for analysis.
     outputFormat: None, Yaml, Json, NUnit3, Csv   # Optional. The format to use when writing results to disk.
     outputPath: string                            # Optional. The file path to write results to.
@@ -69,6 +70,10 @@ Install PSRule modules using the `ps-rule-install` task.
 If the modules have not been installed,
 the latest stable version will be installed from the PowerShell Gallery automatically.
 For example: _PSRule.Rules.Azure,PSRule.Rules.Kubernetes_
+- **baseline**: The name of a PSRule baseline to use.
+Baselines can be used from modules or specified in a separate file.
+To use a baseline included in a module use `modules:` with `baseline:`.
+To use a baseline specified in a separate file use `source:` with `baseline:`.
 - **source**: An path containing rules to use for analysis.
 Use this option to include rules not installed as a PowerShell module.
 This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
@@ -109,4 +114,19 @@ steps:
     modules: 'PSRule.Rules.Azure'            # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
     outputFormat: NUnit3                     # Save results to an NUnit report.
     outputPath: reports/ps-rule-results.xml  # Write NUnit report to 'reports/ps-rule-results.xml'.
+```
+
+### Example: Run analysis using an included baseline
+
+Run analysis of files within `out/` and all subdirectories using the named baseline `Azure.GA_2020_12`.
+
+```yaml
+steps:
+- task: ps-rule-assert@0
+  inputs:
+    inputType: inputPath
+    inputPath: 'out/'              # Read objects from files in 'out/'.
+    modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
+    baseline: 'Azure.GA_2020_12'   # Use the 'Azure.GA_2020_12' baseline included within PSRule.Rules.Azure.
+    source: '.ps-rule/'            # Additionally, analyze object using custom rules from '.ps-rule/'.
 ```

--- a/tasks/ps-rule-assert/powershell.ps1
+++ b/tasks/ps-rule-assert/powershell.ps1
@@ -30,6 +30,10 @@ param (
     [Parameter(Mandatory = $False)]
     [String]$Modules = (Get-VstsInput -Name 'modules'),
 
+    # The name of a baseline to use
+    [Parameter(Mandatory = $False)]
+    [String]$Baseline = (Get-VstsInput -Name 'baseline'),
+
     # The output format
     [Parameter(Mandatory = $False)]
     [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv')]
@@ -37,7 +41,7 @@ param (
 
     # The path to store formatted output
     [Parameter(Mandatory = $False)]
-    [String]$OutputPath = (Get-VstsInput -Name 'outputPath') 
+    [String]$OutputPath = (Get-VstsInput -Name 'outputPath')
 )
 
 if ($Env:SYSTEM_DEBUG -eq 'true') {
@@ -123,6 +127,7 @@ Write-Host '';
 Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";
+Write-Host "[info] Using Baseline: $Baseline";
 Write-Host "[info] Using InputType: $InputType";
 Write-Host "[info] Using InputPath: $InputPath";
 Write-Host "[info] Using OutputFormat: $OutputFormat";
@@ -137,6 +142,10 @@ try {
     }
     WriteDebug "Preparing command-line:";
     WriteDebug ([String]::Concat('-Path ''', $Source, ''''));
+    if (![String]::IsNullOrEmpty($Baseline)) {
+        $invokeParams['Baseline'] = $Baseline;
+        WriteDebug ([String]::Concat('-Baseline ''', $Baseline, ''''));
+    }
     if (![String]::IsNullOrEmpty($Modules)) {
         $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);
         $invokeParams['Module'] = $moduleNames;

--- a/tasks/ps-rule-assert/powershell.ts
+++ b/tasks/ps-rule-assert/powershell.ts
@@ -19,6 +19,7 @@ async function run() {
         let input_inputPath: string = task.getInput('inputPath', /*required*/ true);
         let input_source: string = task.getPathInput('source', /*required*/ false, /*check*/ false);
         let input_modules: string = task.getInput('modules', /*required*/ false);
+        let input_baseline: string = task.getInput('baseline', /*required*/ false);
         let input_outputFormat: string = task.getPathInput('outputFormat', /*required*/ false, /*check*/ false) || 'None';
         let input_outputPath: string = task.getPathInput('outputPath', /*required*/ false, /*check*/ false);
 
@@ -37,6 +38,9 @@ async function run() {
         }
         if (input_modules !== undefined) {
             contents.push(`$scriptParams['Modules'] = '${input_modules}'`);
+        }
+        if (input_baseline !== undefined) {
+            contents.push(`$scriptParams['Baseline'] = '${input_baseline}'`);
         }
         if (input_outputFormat !== undefined) {
             contents.push(`$scriptParams['OutputFormat'] = '${input_outputFormat}'`);

--- a/tasks/ps-rule-assert/task.json
+++ b/tasks/ps-rule-assert/task.json
@@ -78,6 +78,14 @@
             "helpMarkDown": "A comma separated list of modules to use for analysis."
         },
         {
+            "name": "baseline",
+            "type": "string",
+            "label": "Baseline",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "The name of a PSRule baseline to use."
+        },
+        {
             "name": "outputFormat",
             "type": "pickList",
             "label": "Output format",


### PR DESCRIPTION
## PR Summary

- Added support for using baselines. #46
  - Specify a named baseline by using `baseline: '<baseline_name>'`.
  - Baselines can be included from individual files or modules using `source:` and `modules:`.

Fixes #46

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
