### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v0.9.0
+
 What's changed since v0.8.0:
 
 - Engineering:
   - Bump PSRule dependency to v1.2.0. [#139](https://github.com/microsoft/PSRule-pipelines/issues/139)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v120)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v120).
+  - Bump azure-pipelines-task-lib to 3.1.0. [#123](https://github.com/microsoft/PSRule-pipelines/pull/123)
 
 ## v0.8.0
 
@@ -23,7 +26,7 @@ What's changed since v0.7.0:
   - Added support for markdown output format. [#114](https://github.com/microsoft/PSRule-pipelines/issues/114)
 - Engineering:
   - Bump PSRule dependency to v1.0.1. [#106](https://github.com/microsoft/PSRule-pipelines/issues/106)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v101)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v101).
 
 ## v0.7.0
 
@@ -31,7 +34,7 @@ What's changed since v0.6.0:
 
 - Engineering:
   - Bump PSRule dependency to v1.0.0. [#82](https://github.com/microsoft/PSRule-pipelines/issues/82)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100).
 
 ## v0.6.0
 
@@ -39,7 +42,7 @@ What's changed since v0.5.0:
 
 - Engineering:
   - Bump PSRule dependency to v0.21.0. [#72](https://github.com/microsoft/PSRule-pipelines/issues/72)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0210)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0210).
 
 ## v0.5.0
 
@@ -52,7 +55,7 @@ What's changed since v0.4.0:
     - See [upgrade notes][upgrade-v0.5.0] for details on breaking change.
 - Engineering:
   - Bump PSRule dependency to v0.20.0. [#54](https://github.com/microsoft/PSRule-pipelines/issues/54)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200).
 
 See [upgrade notes][upgrade-v0.5.0] for helpful information when upgrading from previous versions.
 
@@ -64,7 +67,7 @@ What's changed since v0.3.0:
 
 - Engineering:
   - Bump PSRule dependency to v0.19.0. [#31](https://github.com/microsoft/PSRule-pipelines/issues/31)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0190)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0190).
 
 ## v0.3.0
 
@@ -72,7 +75,7 @@ What's changed since v0.2.0:
 
 - Engineering:
   - Bump PSRule dependency to v0.18.0. [#24](https://github.com/microsoft/PSRule-pipelines/issues/24)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0180)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0180).
 
 ## v0.2.0
 
@@ -80,7 +83,7 @@ What's changed since v0.1.0:
 
 - Engineering:
   - Bump PSRule dependency to v0.17.0. [#19](https://github.com/microsoft/PSRule-pipelines/issues/19)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0170)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0170).
 - Bug fixes:
   - Fixed examples in documentation referencing outputType instead of outputFormat. [#17](https://github.com/microsoft/PSRule-pipelines/issues/17)
 


### PR DESCRIPTION
## PR Summary

What's changed since v0.8.0:

- Engineering:
  - Bump PSRule dependency to v1.2.0. #139
  - Bump azure-pipelines-task-lib to 3.1.0. #123

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
