### PR TITLE
Bump PSRule dependency to v1.6.0 #200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 What's changed since v1.0.0:
 
 - Engineering:
-  - Bump PSRule dependency to v1.5.0. [#184](https://github.com/microsoft/PSRule-pipelines/issues/184)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v150).
-  - Bump azure-pipelines-task-lib to 3.1.5. [#188](https://github.com/microsoft/PSRule-pipelines/pull/188)
+  - Bump PSRule dependency to v1.6.0. [#200](https://github.com/microsoft/PSRule-pipelines/issues/200)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v160).
+  - Bump azure-pipelines-task-lib to 3.1.6. [#195](https://github.com/microsoft/PSRule-pipelines/pull/195)
 
 ## v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ steps:
 
 ## Changes and versioning
 
-Extensions and tasks in this repository will use the [semantic versioning](http://semver.org/) model to declare breaking changes from v1.0.0.
-Prior to v1.0.0, breaking changes may be introduced in minor (0.x.0) version increments.
-For a list of module changes please see the [change log].
+Extensions and tasks in this repository uses [semantic versioning](http://semver.org/) to declare breaking changes.
+For a list of module changes please see the [change log](CHANGELOG.md).
 
 ## Contributing
 

--- a/extension.md
+++ b/extension.md
@@ -69,8 +69,7 @@ steps:
 
 ## Changes and versioning
 
-Extensions and tasks in this repository will use the [semantic versioning](http://semver.org/) model to declare breaking changes from v1.0.0.
-Prior to v1.0.0, breaking changes may be introduced in minor (0.x.0) version increments.
+Extensions and tasks in this repository uses [semantic versioning](http://semver.org/) to declare breaking changes.
 For a list of module changes please see the [change log].
 
 ## Contributing

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -169,10 +169,10 @@ task PSRule NuGet, {
     if (!(Test-Path -Path out/dist/ps_modules)) {
         $Null = New-Item -Path out/dist/ps_modules -ItemType Directory -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.5.0 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name PSRule -Scope CurrentUser -MinimumVersion 1.5.0 -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.6.0 -ErrorAction SilentlyContinue)) {
+        Install-Module -Name PSRule -Scope CurrentUser -MinimumVersion 1.6.0 -Force;
     }
-    Save-Module -Name PSRule -Path out/dist/ps_modules -MinimumVersion 1.5.0;
+    Save-Module -Name PSRule -Path out/dist/ps_modules -MinimumVersion 1.6.0;
     Import-Module -Name PSRule -Verbose:$False;
 }
 

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/PSRule-pipelines/issues
 
 modules:
-  PSRule: ^1.5.0
+  PSRule: ^1.6.0
   VstsTaskSdk: ^0.11.0
   PowerShellGet: ^2.2.3
 


### PR DESCRIPTION
## PR Summary

- Bump PSRule module dependency to v1.6.0.

Fixes #200

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
