### PR TITLE
Fail action when module installation fails #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ What's changed since v1.0.0:
   - Bump PSRule dependency to v1.6.0. [#200](https://github.com/microsoft/PSRule-pipelines/issues/200)
     - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v160).
   - Bump azure-pipelines-task-lib to 3.1.6. [#195](https://github.com/microsoft/PSRule-pipelines/pull/195)
+- Bug fixes:
+  - Fixed assert task to ensure it fails when a dependency module installation fails. [#202](https://github.com/microsoft/PSRule-pipelines/issues/202)
 
 ## v1.0.0
 

--- a/tasks/ps-rule-assert/task.json
+++ b/tasks/ps-rule-assert/task.json
@@ -125,6 +125,8 @@
         }
     },
     "messages": {
-        "AssertFailed": "One or more assertions failed."
+        "AssertFailed": "One or more assertions failed.",
+        "DependencyFailed": "An error occurred installing a dependency module.",
+        "ImportFailed": "An error occurred importing module 'PSRule'."
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed assert task to ensure it fails when a dependency module installation fails. 

Fixes #202

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
