### PR TITLE
Added support for conventions #211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+- General improvements:
+  - Added support for conventions. [#211](https://github.com/microsoft/PSRule-pipelines/issues/211)
+    - Specify one or more conventions by using `conventions: '<convention1>,<convention2>'`.
+    - Conventions can be included from individual files or modules using `source:` and `modules:`.
+
 ## v1.1.1
 
 What's changed since v1.1.0:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -52,6 +52,7 @@ steps:
     inputPath: string                                       # Required. The path PSRule will look for files to validate.
     modules: string                                         # Optional. A comma separated list of modules to use for analysis.
     baseline: string                                        # Optional. The name of a PSRule baseline to use.
+    conventions: string                                     # Optional. A comma separated list of conventions to use.
     source: string                                          # Optional. An path containing rules to use for analysis.
     outputFormat: None, Yaml, Json, Markdown, NUnit3, Csv   # Optional. The format to use when writing results to disk.
     outputPath: string                                      # Optional. The file path to write results to.
@@ -74,6 +75,9 @@ For example: _PSRule.Rules.Azure,PSRule.Rules.Kubernetes_
 Baselines can be used from modules or specified in a separate file.
 To use a baseline included in a module use `modules:` with `baseline:`.
 To use a baseline specified in a separate file use `source:` with `baseline:`.
+- **conventions**: A comma separated list of conventions to use.
+Conventions can be used from modules or specified in a separate file.
+For example: _Monitor.LogAnalytics.Import_
 - **source**: An path containing rules to use for analysis.
 Use this option to include rules not installed as a PowerShell module.
 This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
@@ -118,7 +122,7 @@ steps:
 
 ### Example: Run analysis using an included baseline
 
-Run analysis of files within `out/` and all subdirectories using the named baseline `Azure.GA_2020_12`.
+Run analysis of files within `out/` and all subdirectories using the named baseline `Azure.GA_2021_06`.
 
 ```yaml
 steps:
@@ -127,6 +131,6 @@ steps:
     inputType: inputPath
     inputPath: 'out/'              # Read objects from files in 'out/'.
     modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
-    baseline: 'Azure.GA_2020_12'   # Use the 'Azure.GA_2020_12' baseline included within PSRule.Rules.Azure.
+    baseline: 'Azure.GA_2021_06'   # Use the 'Azure.GA_2021_06' baseline included within PSRule.Rules.Azure.
     source: '.ps-rule/'            # Additionally, analyze object using custom rules from '.ps-rule/'.
 ```

--- a/tasks/ps-rule-assert/powershell.ps1
+++ b/tasks/ps-rule-assert/powershell.ps1
@@ -34,6 +34,10 @@ param (
     [Parameter(Mandatory = $False)]
     [String]$Baseline = (Get-VstsInput -Name 'baseline'),
 
+    # The conventions to use
+    [Parameter(Mandatory = $False)]
+    [String]$Conventions = (Get-VstsInput -Name 'conventions'),
+
     # The output format
     [Parameter(Mandatory = $False)]
     [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'NUnit3', 'Csv')]
@@ -62,6 +66,14 @@ if ([String]::IsNullOrEmpty($Source)) {
 if (!(Test-Path -Path $Source)) {
     Write-Host "[info] Source '$Source' does not exist.";
     Write-Host '';
+}
+if (![String]::IsNullOrEmpty($Conventions)) {
+    $Conventions = @($Contentions.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object {
+        $_.Trim();
+    });
+}
+else {
+    $Conventions = @();
 }
 
 function WriteDebug {
@@ -147,6 +159,7 @@ Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";
 Write-Host "[info] Using Baseline: $Baseline";
+Write-Host "[info] Using Conventions: $Conventions";
 Write-Host "[info] Using InputType: $InputType";
 Write-Host "[info] Using InputPath: $InputPath";
 Write-Host "[info] Using OutputFormat: $OutputFormat";
@@ -164,6 +177,10 @@ try {
     if (![String]::IsNullOrEmpty($Baseline)) {
         $invokeParams['Baseline'] = $Baseline;
         WriteDebug ([String]::Concat('-Baseline ''', $Baseline, ''''));
+    }
+    if ($Conventions.Length -gt 0) {
+        $invokeParams['Convention'] = $Conventions;
+        WriteDebug ([String]::Concat('-Convention ', [String]::Join(', ', $Conventions)));
     }
     if (![String]::IsNullOrEmpty($Modules)) {
         $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);

--- a/tasks/ps-rule-assert/powershell.ts
+++ b/tasks/ps-rule-assert/powershell.ts
@@ -20,6 +20,7 @@ async function run() {
         let input_source: string = task.getPathInput('source', /*required*/ false, /*check*/ false);
         let input_modules: string = task.getInput('modules', /*required*/ false);
         let input_baseline: string = task.getInput('baseline', /*required*/ false);
+        let input_conventions: string = task.getInput('conventions', /*required*/ false);
         let input_outputFormat: string = task.getPathInput('outputFormat', /*required*/ false, /*check*/ false) || 'None';
         let input_outputPath: string = task.getPathInput('outputPath', /*required*/ false, /*check*/ false);
 
@@ -41,6 +42,9 @@ async function run() {
         }
         if (input_baseline !== undefined) {
             contents.push(`$scriptParams['Baseline'] = '${input_baseline}'`);
+        }
+        if (input_modules !== undefined) {
+            contents.push(`$scriptParams['Conventions'] = '${input_conventions}'`);
         }
         if (input_outputFormat !== undefined) {
             contents.push(`$scriptParams['OutputFormat'] = '${input_outputFormat}'`);

--- a/tasks/ps-rule-assert/task.json
+++ b/tasks/ps-rule-assert/task.json
@@ -86,6 +86,14 @@
             "helpMarkDown": "The name of a PSRule baseline to use."
         },
         {
+            "name": "conventions",
+            "type": "string",
+            "label": "Conventions",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "A comma separated list of conventions to use."
+        },
+        {
             "name": "outputFormat",
             "type": "pickList",
             "label": "Output format",


### PR DESCRIPTION
## PR Summary

- Added support for conventions.
  - Specify one or more conventions by using `conventions: '<convention1>,<convention2>'`.
  - Conventions can be included from individual files or modules using `source:` and `modules:`.

Fixes #211 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
