### PR TITLE
Bump PSRule dependency to v1.9.0 #256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.3.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.9.0. [#256](https://github.com/microsoft/PSRule-pipelines/issues/256)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v190).
+
 ## v1.3.0
 
 What's changed since v1.2.1:

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -169,10 +169,10 @@ task PSRule NuGet, {
     if (!(Test-Path -Path out/dist/ps_modules)) {
         $Null = New-Item -Path out/dist/ps_modules -ItemType Directory -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.8.0 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name PSRule -Scope CurrentUser -MinimumVersion 1.8.0 -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.9.0 -ErrorAction SilentlyContinue)) {
+        Install-Module -Name PSRule -Scope CurrentUser -MinimumVersion 1.9.0 -Force;
     }
-    Save-Module -Name PSRule -Path out/dist/ps_modules -MinimumVersion 1.8.0;
+    Save-Module -Name PSRule -Path out/dist/ps_modules -MinimumVersion 1.9.0;
     Import-Module -Name PSRule -Verbose:$False;
 }
 

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/PSRule-pipelines/issues
 
 modules:
-  PSRule: ^1.8.0
+  PSRule: ^1.9.0
   VstsTaskSdk: ^0.11.0
   PowerShellGet: ^2.2.3
 


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.9.0.

Fixes #256 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
