### PR TITLE
Added updates #353 #314

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "**/.azure-pipelines/**/*.yaml": "azure-pipelines"
     },
     "cSpell.words": [
-        "cmdlets"
+        "cmdlets",
+        "Sarif"
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "test",
             "type": "shell",
-            "command": "Invoke-Build Rules -AssertStyle Client",
+            "command": "Invoke-Build Test",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,21 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since v1.5.0:
 
-- General improvements:
-  - Expose more rule error output in CI. [#308](https://github.com/microsoft/PSRule-pipelines/issues/308)
 - New features:
+  - Added support for PSRule v2. [#312](https://github.com/microsoft/PSRule-pipelines/issues/312)
+    - Added `ps-rule-assert@2` task for PSRule v2.
+    - Added `ps-rule-install@2` task for PSRule v2.
   - Added support for outputting analysis results as SARIF. [#315](https://github.com/microsoft/PSRule-pipelines/issues/315)
     - To use the SARIF output format set the `outputFormat` parameter to `Sarif`.
     - Currently a pre-release version of PSRule must be used.
-- Engineering:
-  - Preparing for PSRule v2 support. [#312](https://github.com/microsoft/PSRule-pipelines/issues/312)
-    - Added `ps-rule-assert@2` task for PSRule v2.
-    - Added `ps-rule-install@2` task for PSRule v2.
+  - Added the ability to use a specific version of PSRule. [#314](https://github.com/microsoft/PSRule-pipelines/issues/314)
+    - To install a specific version set the version parameter.
+    - By default, the latest stable version of PSRule is used.
+  - Added the ability to use an alternative PowerShell repository. [#353](https://github.com/microsoft/PSRule-pipelines/issues/353)
+    - Register and authenticate to the repository in PowerShell if required.
+    - Configure repository to install modules from the named repository.
+- General improvements:
+  - Expose more rule error output in CI. [#308](https://github.com/microsoft/PSRule-pipelines/issues/308)
 
 ## v1.5.0
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -16,6 +16,7 @@ steps:
     module: string        # Required. The name of a rule module to install.
     latest: boolean       # Optional. Determine if the installed module is updated to the latest version.
     prerelease: boolean   # Optional. Determine if a pre-release module version is installed.
+    repository: string    # Optional. The name of the PowerShell repository where PSRule modules are installed from.
 ```
 
 - **module**: The name of a rule module to install.
@@ -23,6 +24,10 @@ The module will be installed from the PowerShell Gallery.
 For example: _PSRule.Rules.Azure_
 - **latest**: Determine if the installed module is updated to the latest version.
 - **prerelease**: Determine if a pre-release module version is installed.
+- **repository**: The name of the PowerShell repository where PSRule modules are installed from.
+  By default this is the PowerShell Gallery.
+  When configured, PowerShell modules are installed from this repository.
+  Before calling the `ps-rule-install`, register and authenticate to the repository if required.
 
 ### Example: Installing a rule module
 
@@ -57,38 +62,54 @@ steps:
     outputFormat: None, Yaml, Json, Markdown, NUnit3, Csv   # Optional. The format to use when writing results to disk.
     outputPath: string                                      # Optional. The file path to write results to.
     path: string                                            # Optional. The working directory PSRule is run from.
+    prerelease: boolean                                     # Optional. Determine if a pre-release module version is installed.
+    repository: string                                      # Optional. The name of the PowerShell repository where PSRule modules are installed from.
+    version: string                                         # Optional. The specific version of PSRule to use.
 ```
 
 - **inputType**: Determines the type of input to use for PSRule.
-Either `repository` or `inputPath`.
-When `inputType: inputPath` is used, supported file formats within `inputPath` will be read as objects.
-When `inputType: repository` is used, the structure of the repository will be analyzed instead.
+  Either `repository` or `inputPath`.
+  The default is `repository`.
+  When `inputType: inputPath` is used, supported file formats within `inputPath` will be read as objects.
+  When `inputType: repository` is used, the structure of the repository will be analyzed instead.
 - **inputPath**: Set the `inputPath` to determine where PSRule will look for input files.
-When `inputType: inputPath` this is binds to the [-InputPath](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-inputpath) parameter.
-When `inputType: repository` this will be the repository root that PSRule analyzes.
+  When `inputType: inputPath` this is binds to the [-InputPath](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-inputpath) parameter.
+  When `inputType: repository` this will be the repository root that PSRule analyzes.
 - **modules**: A comma separated list of modules to use for analysis.
-Install PSRule modules using the `ps-rule-install` task.
-If the modules have not been installed,
-the latest stable version will be installed from the PowerShell Gallery automatically.
-For example: _PSRule.Rules.Azure,PSRule.Rules.Kubernetes_
+  Install PSRule modules using the `ps-rule-install` task.
+  If the modules have not been installed,
+  the latest stable version will be installed from the PowerShell Gallery automatically.
+  For example: _PSRule.Rules.Azure,PSRule.Rules.Kubernetes_
 - **baseline**: The name of a PSRule baseline to use.
-Baselines can be used from modules or specified in a separate file.
-To use a baseline included in a module use `modules:` with `baseline:`.
-To use a baseline specified in a separate file use `source:` with `baseline:`.
+  Baselines can be used from modules or specified in a separate file.
+  To use a baseline included in a module use `modules:` with `baseline:`.
+  To use a baseline specified in a separate file use `source:` with `baseline:`.
 - **conventions**: A comma separated list of conventions to use.
-Conventions can be used from modules or specified in a separate file.
-For example: _Monitor.LogAnalytics.Import_
+  Conventions can be used from modules or specified in a separate file.
+  For example: _Monitor.LogAnalytics.Import_
 - **source**: An path containing rules to use for analysis.
-Use this option to include rules not installed as a PowerShell module.
-This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
+  Use this option to include rules not installed as a PowerShell module.
+  This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
 - **outputFormat**: Output results can be written to disk in addition to the default output.
-Use this option to determine the format to write results.
-By default, results are not written to disk.
-This binds to the [-OutputFormat](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-outputformat) parameter.
+  Use this option to determine the format to write results.
+  By default, results are not written to disk.
+  This binds to the [-OutputFormat](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-outputformat) parameter.
 - **outputPath**: The file path to write results to.
-This binds to the [-OutputPath](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-outputpath) parameter.
+  This binds to the [-OutputPath](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-outputpath) parameter.
 - **path**: The working directory PSRule is run from.
-Options specified in `ps-rule.yaml` from this directory will be used unless overridden by inputs.
+  Options specified in `ps-rule.yaml` from this directory will be used unless overridden by inputs.
+- **prerelease**: Determine if a pre-release module versions are installed.
+  When set to true the latest pre-release or stable module version is installed.
+  If this input is not configured, invalid, or set to false only stable module versions will be installed.
+- **repository**: The name of the PowerShell repository where PSRule modules are installed from.
+  By default this is the PowerShell Gallery.
+  When configured, PowerShell modules are installed from this repository.
+  Before calling the `ps-rule-assert`, register and authenticate to the repository if required.
+- **version**: The specific version of PSRule to use.
+  By default, the latest stable version of PSRule will be used. When set:
+  - The specific version of PSRule will be installed and imported for use.
+  - If a pre-release version is specified, `prerelease: true` must also be specified.
+  - If the version is not found, an error will be thrown.
 
 ### Example: Run analysis from input files
 
@@ -122,7 +143,7 @@ steps:
 
 ### Example: Run analysis using an included baseline
 
-Run analysis of files within `out/` and all subdirectories using the named baseline `Azure.GA_2021_06`.
+Run analysis of files within `out/` and all subdirectories using the named baseline `Azure.GA_2021_12`.
 
 ```yaml
 steps:
@@ -131,6 +152,6 @@ steps:
     inputType: inputPath
     inputPath: 'out/'              # Read objects from files in 'out/'.
     modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
-    baseline: 'Azure.GA_2021_06'   # Use the 'Azure.GA_2021_06' baseline included within PSRule.Rules.Azure.
+    baseline: 'Azure.GA_2021_12'   # Use the 'Azure.GA_2021_12' baseline included within PSRule.Rules.Azure.
     source: '.ps-rule/'            # Additionally, analyze object using custom rules from '.ps-rule/'.
 ```

--- a/modules.json
+++ b/modules.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "PSRule": {
-      "version": "1.11.1"
+      "version": "2.0.0"
     },
     "VstsTaskSdk": {
       "version": "0.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-            "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -572,9 +572,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -1370,9 +1370,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+            "version": "13.13.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+            "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -1425,9 +1425,9 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1635,32 +1635,32 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             },
             "engines": {
                 "node": ">=8.6"
             }
         },
         "node_modules/mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dependencies": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.52.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -2317,9 +2317,9 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-            "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -2695,9 +2695,9 @@
             }
         },
         "debug": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -3206,9 +3206,9 @@
             }
         },
         "globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+            "version": "13.13.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+            "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -3243,9 +3243,9 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "http-basic": {
             "version": "8.1.3",
@@ -3407,26 +3407,26 @@
             "dev": true
         },
         "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             }
         },
         "mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "requires": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.52.0"
             }
         },
         "minimatch": {

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -268,7 +268,7 @@ task PackageRestore {
 }
 
 # Synopsis: Build and clean.
-task . Test, Rules
+task . Build, Rules
 
 # Synopsis: Build the project
 task Build Clean, PackageRestore, BuildExtension, VersionExtension

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -212,6 +212,8 @@ task Rules Dependencies, {
     $assertParams = @{
         OutputFormat = 'NUnit3'
         ErrorAction = 'Stop'
+        Format = 'File'
+        InputPath = '.'
     }
     Assert-PSRule @assertParams -OutputPath reports/ps-rule-file.xml;
 }

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -7,10 +7,7 @@ param (
     [String]$Build = '0.0.1',
 
     [Parameter(Mandatory = $False)]
-    [String]$Configuration = 'Debug',
-
-    [Parameter(Mandatory = $False)]
-    [String]$AssertStyle = 'AzurePipelines'
+    [String]$Configuration = 'Debug'
 )
 
 Write-Host -Object "[Pipeline] -- PWD: $PWD" -ForegroundColor Green;
@@ -79,54 +76,20 @@ function CopyExtensionFiles {
     }
 }
 
-function Get-RepoRuleData {
-    [CmdletBinding()]
-    param (
-        [Parameter(Position = 0, Mandatory = $False)]
-        [String]$Path = $PWD
-    )
-    process {
-        GetPathInfo -Path $Path -Verbose:$VerbosePreference;
-    }
-}
-
-function GetPathInfo {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $True)]
-        [String]$Path
-    )
-    begin {
-        $items = New-Object -TypeName System.Collections.ArrayList;
-    }
-    process {
-        $Null = $items.Add((Get-Item -Path $Path));
-        $files = @(Get-ChildItem -Path $Path -File -Recurse -Include *.ps1,*.ts,*.psm1,*.psd1,*.cs | Where-Object {
-            !($_.FullName -like "*.Designer.cs") -and
-            !($_.FullName -like "*/bin/*") -and
-            !($_.FullName -like "*/obj/*") -and
-            !($_.FullName -like "*\obj\*") -and
-            !($_.FullName -like "*\bin\*") -and
-            !($_.FullName -like "*\out\*") -and
-            !($_.FullName -like "*/out/*") -and
-            !($_.FullName -like "*\node_modules\*") -and
-            !($_.FullName -like "*/node_modules/*")
-        });
-        $Null = $items.AddRange($files);
-    }
-    end {
-        $items;
-    }
-}
-
 function UpdateTaskVersion {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True)]
-        [String]$Path
+        [String]$Path,
+
+        [Parameter(Mandatory = $False)]
+        [String]$Build = $Env:BUILD_BUILDNUMBER
     )
     process {
-        $buildNumber = [int]::Parse($Env:BUILD_BUILDNUMBER.Split('-', [System.StringSplitOptions]::RemoveEmptyEntries)[1].Replace('B', ''));
+        if ([String]::IsNullOrEmpty($Build)) {
+            $Build = '0.0.1-B000000000';
+        }
+        $buildNumber = [int]::Parse($Build.Split('-', [System.StringSplitOptions]::RemoveEmptyEntries)[1].Replace('B', ''));
         Get-ChildItem -Path $Path -Filter task.json -Recurse | ForEach-Object {
             $filePath = $_.FullName;
             $taskContent = Get-Content -Raw -Path $filePath | ConvertFrom-Json;
@@ -143,62 +106,26 @@ task NuGet {
     }
 }
 
-# Synopsis: Install Pester module
-task Pester NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name Pester -RequiredVersion 4.10.1 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck;
-    }
-    Import-Module -Name Pester -RequiredVersion 4.10.1 -Verbose:$False;
+task Dependencies NuGet, {
+    Import-Module $PWD/scripts/dependencies.psm1;
+    Install-Dependencies -Path $PWD/modules.json;
 }
 
-# Synopsis: Install PSScriptAnalyzer module
-task PSScriptAnalyzer NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSScriptAnalyzer -MinimumVersion 1.18.3 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name PSScriptAnalyzer -MinimumVersion 1.18.3 -Scope CurrentUser -Force;
-    }
-    Import-Module -Name PSScriptAnalyzer -Verbose:$False;
+task SaveDependencies NuGet, PSRule, {
+    Import-Module $PWD/scripts/dependencies.psm1;
+    Save-Dependencies -Path $PWD/modules.json -OutputPath out/dist/ps_modules;
 }
 
-# Synopsis: Install PlatyPS module
-task platyPS {
-    if ($Null -eq (Get-InstalledModule -Name PlatyPS -MinimumVersion 0.14.0 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name PlatyPS -Scope CurrentUser -MinimumVersion 0.14.0 -Force;
-    }
-    Import-Module -Name PlatyPS -Verbose:$False;
-}
-
-# Synopsis: Install PSRule modules
+# Synopsis: Install PSRule older version of PSRule for V1
 task PSRule NuGet, {
     if (!(Test-Path -Path out/dist/ps_modules)) {
         $Null = New-Item -Path out/dist/ps_modules -ItemType Directory -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name PSRule -RequiredVersion 1.11.0 -ErrorAction SilentlyContinue)) {
-        Install-Module -Name PSRule -Scope CurrentUser -RequiredVersion 1.11.0 -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -RequiredVersion 1.11.1 -ErrorAction SilentlyContinue)) {
+        Install-Module -Name PSRule -Repository PSGallery -Scope CurrentUser -RequiredVersion 1.11.1 -Force;
     }
-    Save-Module -Name PSRule -Path out/dist/ps_modules -RequiredVersion 1.11.0;
+    Save-Module -Name PSRule -Repository PSGallery -Path out/dist/ps_modules -RequiredVersion 1.11.1;
     Import-Module -Name PSRule -Verbose:$False;
-}
-
-# Synopsis: Install VstsTaskSdk module
-task VstsTaskSdk NuGet, {
-    if (!(Test-Path -Path out/ps_modules)) {
-        $Null = New-Item -Path out/ps_modules -ItemType Directory -Force;
-    }
-    Save-Module -Name VstsTaskSdk -Path out/ps_modules -RequiredVersion 0.11.0;
-
-    foreach ($task in $tasks) {
-        $taskRoot = $task.Split('V')[0];
-        Copy-Item -Path out/ps_modules/VstsTaskSdk/0.11.0/* -Destination "out/dist/$taskRoot/$task/ps_modules/VstsTaskSdk/" -Recurse -Force;
-    }
-
-    Remove-Item  -Path out/ps_modules/VstsTaskSdk -Force -Recurse;
-}
-
-task PowerShellGet NuGet, {
-    if (!(Test-Path -Path out/dist/ps_modules)) {
-        $Null = New-Item -Path out/dist/ps_modules -ItemType Directory -Force;
-    }
-    Save-Module -Name PowerShellGet -Path out/dist/ps_modules -MinimumVersion 2.2.3;
 }
 
 # Synopsis: Remove temp files.
@@ -217,6 +144,8 @@ task CopyExtension {
 
     # Copy manifests
     Copy-Item -Path vss-extension.json -Destination out/dist/;
+    Copy-Item -Path modules.json -Destination out/dist/;
+
 
     # Copy icon
     if (!(Test-Path -Path out/dist/images)) {
@@ -230,7 +159,7 @@ task CopyExtension {
     Copy-Item -Path LICENSE -Destination out/dist/;
 }
 
-task BuildExtension CopyExtension, PSRule, PowerShellGet, VstsTaskSdk, {
+task BuildExtension CopyExtension, SaveDependencies, {
     Write-Host '> Building extension' -ForegroundColor Green;
 
     foreach ($task in $tasks) {
@@ -279,31 +208,50 @@ task GetVersionInfo {
 }
 
 # Synopsis: Run validation
-task Rules PSRule, {
+task Rules Dependencies, {
     $assertParams = @{
-        Path = './.ps-rule/'
-        Style = $AssertStyle
         OutputFormat = 'NUnit3'
         ErrorAction = 'Stop'
     }
-    Get-RepoRuleData -Path $PWD |
-        Assert-PSRule @assertParams -OutputPath reports/ps-rule-file.xml;
+    Assert-PSRule @assertParams -OutputPath reports/ps-rule-file.xml;
 }
 
-task TestModule Pester, PSScriptAnalyzer, {
+task TestModule Dependencies, {
     # Run Pester tests
-    $pesterParams = @{ Path = $PWD; OutputFile = 'reports/pester-unit.xml'; OutputFormat = 'NUnitXml'; PesterOption = @{ IncludeVSCodeMarker = $True }; PassThru = $True; };
+    $pesterOptions = @{
+        Run        = @{
+            Path     = (Join-Path -Path $PWD -ChildPath tests/);
+            PassThru = $True;
+        };
+        TestResult = @{
+            Enabled      = $True;
+            OutputFormat = 'NUnitXml';
+            OutputPath   = 'reports/pester-unit.xml';
+        };
+    };
 
     if ($CodeCoverage) {
-        $pesterParams.Add('CodeCoverage', (Join-Path -Path $PWD -ChildPath 'tasks/**/*.ps1'));
-        $pesterParams.Add('CodeCoverageOutputFile', (Join-Path -Path $PWD -ChildPath reports/pester-coverage.xml));
+        $codeCoverageOptions = @{
+            Enabled    = $True;
+            OutputPath = (Join-Path -Path $PWD -ChildPath 'reports/pester-coverage.xml');
+            Path       = (Join-Path -Path $PWD -ChildPath 'tasks/**/*.ps1');
+        };
+
+        $pesterOptions.Add('CodeCoverage', $codeCoverageOptions);
     }
 
     if (!(Test-Path -Path reports)) {
         $Null = New-Item -Path reports -ItemType Directory -Force;
     }
 
-    $results = Invoke-Pester @pesterParams;
+    if ($Null -ne $TestGroup) {
+        $pesterOptions.Add('Filter', @{ Tag = $TestGroup });
+    }
+
+    # https://pester.dev/docs/commands/New-PesterConfiguration
+    $pesterConfiguration = New-PesterConfiguration -Hashtable $pesterOptions;
+
+    $results = Invoke-Pester -Configuration $pesterConfiguration;
 
     # Throw an error if pester tests failed
     if ($Null -eq $results) {
@@ -320,9 +268,9 @@ task PackageRestore {
 }
 
 # Synopsis: Build and clean.
-task . Test
+task . Test, Rules
 
 # Synopsis: Build the project
-task Build Clean, Rules, PackageRestore, BuildExtension, VersionExtension
+task Build Clean, PackageRestore, BuildExtension, VersionExtension
 
 task Test Build, TestModule

--- a/tasks/ps-rule-assertV2/powershell.ts
+++ b/tasks/ps-rule-assertV2/powershell.ts
@@ -23,6 +23,9 @@ async function run() {
         let input_conventions: string = task.getInput('conventions', /*required*/ false);
         let input_outputFormat: string = task.getPathInput('outputFormat', /*required*/ false, /*check*/ false) || 'None';
         let input_outputPath: string = task.getPathInput('outputPath', /*required*/ false, /*check*/ false);
+        let input_prerelease: boolean = task.getBoolInput('prerelease', /*required*/ false);
+        let input_repository: string = task.getInput('repository', /*required*/ false);
+        let input_version: string = task.getInput('version', /*required*/ false);
 
         // Write bootstrap commands to a temporary script file
         let contents: string[] = [];
@@ -51,6 +54,18 @@ async function run() {
         }
         if (input_outputPath !== undefined) {
             contents.push(`$scriptParams['OutputPath'] = '${input_outputPath}'`);
+        }
+        if (input_prerelease !== undefined && input_prerelease) {
+            contents.push(`$scriptParams['PreRelease'] = $True;`);
+        }
+        else {
+            contents.push(`$scriptParams['PreRelease'] = $False;`);
+        }
+        if (input_repository !== undefined) {
+            contents.push(`$scriptParams['Repository'] = '${input_repository}'`);
+        }
+        if (input_version !== undefined) {
+            contents.push(`$scriptParams['Version'] = '${input_version}'`);
         }
 
         // Add PowerShell entry point

--- a/tasks/ps-rule-assertV2/task.json
+++ b/tasks/ps-rule-assertV2/task.json
@@ -118,6 +118,30 @@
             "required": true,
             "helpMarkDown": "The file path to write results to.",
             "visibleRule": "outputFormat != None"
+        },
+        {
+            "name": "prerelease",
+            "type": "boolean",
+            "label": "PreRelease",
+            "required": false,
+            "defaultValue": false,
+            "helpMarkDown": "Determine if a pre-release module version is installed."
+        },
+        {
+            "name": "repository",
+            "type": "string",
+            "label": "Repository",
+            "required": false,
+            "defaultValue": "PSGallery",
+            "helpMarkDown": "The name of the PowerShell repository where PSRule modules are installed from."
+        },
+        {
+            "name": "version",
+            "type": "string",
+            "label": "Version",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "The specific version of PSRule to use."
         }
     ],
     "instanceNameFormat": "Run PSRule analysis",

--- a/tasks/ps-rule-installV2/powershell.ps1
+++ b/tasks/ps-rule-installV2/powershell.ps1
@@ -19,13 +19,21 @@ param (
 
     # Determine if pre-release modules are installed
     [Parameter(Mandatory = $False)]
-    [System.Boolean]$PreRelease = (Get-VstsInput -Name 'prerelease' -AsBool)
+    [System.Boolean]$PreRelease = (Get-VstsInput -Name 'prerelease' -AsBool),
+
+    # The name of the PowerShell repository where PSRule modules are installed from.
+    [String]$Repository = (Get-VstsInput -Name 'repository')
 )
 
 if ($Env:SYSTEM_DEBUG -eq 'true') {
     $VerbosePreference = 'Continue';
 }
 $ProgressPreference = 'SilentlyContinue';
+
+# Set repository
+if ([String]::IsNullOrEmpty($Repository)) {
+    $Repository = 'PSGallery'
+}
 
 Write-Host '';
 Write-Host "[info] Using PreRelease: $PreRelease";
@@ -80,7 +88,7 @@ foreach ($m in $moduleNames) {
     Write-Host "[info] Checking module: $m";
     if ($Null -eq (Get-InstalledModule -Name $m -ErrorAction Ignore)) {
         Write-Host "[info] Installing module: $m";
-        $Null = Install-Module -Name $m @moduleParams -AllowClobber;
+        $Null = Install-Module -Name $m @moduleParams -Repository $Repository -AllowClobber;
     }
     elseif ($Latest) {
         Write-Host "[info] Updating module: $m";

--- a/tasks/ps-rule-installV2/powershell.ts
+++ b/tasks/ps-rule-installV2/powershell.ts
@@ -17,6 +17,7 @@ async function run() {
         let input_module: string = task.getInput('module', /*required*/ true);
         let input_latest: boolean = task.getBoolInput('latest', /*required*/ true);
         let input_prerelease: boolean = task.getBoolInput('prerelease', /*required*/ true);
+        let input_repository: string = task.getInput('repository', /*required*/ false);
 
         // Write bootstrap commands to a temporary script file
         let contents: string[] = [];
@@ -42,6 +43,9 @@ async function run() {
         }
         else {
             contents.push(`$scriptParams['PreRelease'] = $False;`);
+        }
+        if (input_repository !== undefined) {
+            contents.push(`$scriptParams['Repository'] = '${input_repository}'`);
         }
 
         // Add PowerShell entry point

--- a/tasks/ps-rule-installV2/task.json
+++ b/tasks/ps-rule-installV2/task.json
@@ -56,6 +56,14 @@
             "required": true,
             "helpMarkDown": "Determines if pre-release module versions are installed.",
             "groupName": "advanced"
+        },
+        {
+            "name": "repository",
+            "type": "string",
+            "label": "Repository",
+            "required": false,
+            "defaultValue": "PSGallery",
+            "helpMarkDown": "The name of the PowerShell repository where PSRule modules are installed from."
         }
     ],
     "instanceNameFormat": "Install $(module)",

--- a/tests/Extension.Tests.ps1
+++ b/tests/Extension.Tests.ps1
@@ -6,32 +6,45 @@
 #
 
 [CmdletBinding()]
-param (
+param ()
 
-)
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    # Setup tests paths
+    $rootPath = $PWD;
+    $extensionOut = Join-Path -Path $rootPath -ChildPath 'out/dist/'
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Common;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
+
+    Import-Module -Name VstsTaskSdk -ArgumentList @{ 'NonInteractive' = 'true' };
 }
 
-# Setup tests paths
-$rootPath = $PWD;
+Describe 'Extension V2' {
+    BeforeAll {
+        $entryPointPath = (Join-Path -Path $extensionOut -ChildPath 'ps-rule-assert/ps-rule-assertV2/powershell.ps1');
+    }
 
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Common;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
-
-# Describe 'Extension' {
-#     $entryPointPath = (Join-Path -Path $rootPath -ChildPath 'tasks/ps-rule-assert/powershell.ps1');
-
-#     Context 'With defaults' {
-#         It 'Runs entrypoint' {
-#             . $entryPointPath -Path $PWD;
-#         }
-#     }
-# }
+    Context 'With defaults' {
+        It 'Runs entrypoint' {
+            $taskOptions = @{
+                Path = ''
+                InputType = 'repository'
+                InputPath = ''
+                Source = '.ps-rule/'
+                Modules = ''
+                Baseline = ''
+            }
+            . $entryPointPath @taskOptions;
+        }
+    }
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -52,8 +52,8 @@
             "path": "ps-rule-install"
         },
         {
-            "path": "ps_modules/PSRule",
-            "packagePath": "/ps-rule-assert/ps-rule-assertV0/ps_modules/PSRule"
+            "path": "ps_modules/PSRule/1.11.1",
+            "packagePath": "/ps-rule-assert/ps-rule-assertV0/ps_modules/PSRule/1.11.1"
         },
         {
             "path": "ps_modules/PowerShellGet",
@@ -64,8 +64,8 @@
             "packagePath": "/ps-rule-install/ps-rule-installV0/ps_modules/PackageManagement"
         },
         {
-            "path": "ps_modules/PSRule",
-            "packagePath": "/ps-rule-assert/ps-rule-assertV1/ps_modules/PSRule"
+            "path": "ps_modules/PSRule/1.11.1",
+            "packagePath": "/ps-rule-assert/ps-rule-assertV1/ps_modules/PSRule/1.11.1"
         },
         {
             "path": "ps_modules/PowerShellGet",
@@ -76,8 +76,12 @@
             "packagePath": "/ps-rule-install/ps-rule-installV1/ps_modules/PackageManagement"
         },
         {
-            "path": "ps_modules/PSRule",
-            "packagePath": "/ps-rule-assert/ps-rule-assertV2/ps_modules/PSRule"
+            "path": "modules.json",
+            "packagePath": "/ps-rule-assert/ps-rule-assertV2/modules.json"
+        },
+        {
+            "path": "ps_modules/PSRule/2.0.0",
+            "packagePath": "/ps-rule-assert/ps-rule-assertV2/ps_modules/PSRule/2.0.0"
         },
         {
             "path": "ps_modules/PowerShellGet",


### PR DESCRIPTION
## PR Summary

- Added the ability to use a specific version of PSRule. #314
  - To install a specific version set the version parameter.
  - By default, the latest stable version of PSRule is used.
- Added the ability to use an alternative PowerShell repository. #353
  - Register and authenticate to the repository in PowerShell if required.
  - Configure repository to install modules from the named repository.

Fixes #353 
Fixes #314 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
