### PR TITLE
Release v2.0.0

### DIFF
--- a/.azure-pipelines/loopback-pipeline.yaml
+++ b/.azure-pipelines/loopback-pipeline.yaml
@@ -33,12 +33,12 @@ stages:
     displayName: 'Extension'
     steps:
 
-    - task: ps-rule-install@1
+    - task: ps-rule-install@2
       displayName: Test install task
       inputs:
         module: PSRule.Rules.Azure
 
-    - task: ps-rule-assert@1
+    - task: ps-rule-assert@2
       displayName: Test assert task
       inputs:
         outputFormat: NUnit3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.0.0
+
 What's changed since v1.5.0:
 
 - New features:

--- a/README.md
+++ b/README.md
@@ -47,19 +47,14 @@ For example:
 steps:
 
 # Install PSRule.Rules.Azure from the PowerShell Gallery
-- task: ps-rule-install@1
+- task: ps-rule-install@2
   inputs:
     module: PSRule.Rules.Azure   # Install PSRule.Rules.Azure from the PowerShell Gallery.
-    latest: false                # Only install the module if not already installed.
-    prerelease: false            # Install stable versions only.
 
 # Run analysis from JSON files using the `PSRule.Rules.Azure` module and custom rules from `.ps-rule/`.
-- task: ps-rule-assert@1
+- task: ps-rule-assert@2
   inputs:
-    inputType: inputPath
-    inputPath: 'out/*.json'                  # Read objects from JSON files in 'out/'.
     modules: 'PSRule.Rules.Azure'            # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
-    source: '.ps-rule/'                      # Additionally, analyze object using custom rules from '.ps-rule/'.
     outputFormat: NUnit3                     # Save results to an NUnit report.
     outputPath: reports/ps-rule-results.xml  # Write NUnit report to 'reports/ps-rule-results.xml'.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -11,7 +11,7 @@ Syntax:
 
 ```yaml
 steps:
-- task: ps-rule-install@1
+- task: ps-rule-install@2
   inputs:
     module: string        # Required. The name of a rule module to install.
     latest: boolean       # Optional. Determine if the installed module is updated to the latest version.
@@ -35,7 +35,7 @@ Install the latest stable version of `PSRule.Rules.Azure` from the PowerShell Ga
 
 ```yaml
 steps:
-- task: ps-rule-install@1
+- task: ps-rule-install@2
   inputs:
     module: PSRule.Rules.Azure   # Install PSRule.Rules.Azure from the PowerShell Gallery.
     latest: false                # Only install the module if not already installed.
@@ -51,7 +51,7 @@ Syntax:
 
 ```yaml
 steps:
-- task: ps-rule-assert@1
+- task: ps-rule-assert@2
   inputs:
     inputType: repository, inputPath                        # Required. Determines the type of input to use for PSRule.
     inputPath: string                                       # Required. The path PSRule will look for files to validate.
@@ -117,7 +117,7 @@ Run analysis from JSON files using the `PSRule.Rules.Azure` module and custom ru
 
 ```yaml
 steps:
-- task: ps-rule-assert@1
+- task: ps-rule-assert@2
   inputs:
     inputType: inputPath
     inputPath: 'out/*.json'        # Read objects from JSON files in 'out/'.
@@ -132,9 +132,8 @@ Results are outputted to a NUnit format that can be published using the publish 
 
 ```yaml
 steps:
-- task: ps-rule-assert@1
+- task: ps-rule-assert@2
   inputs:
-    inputType: repository                    # Analyze repository structure.
     inputPath: $(BUILD_SOURCESDIRECTORY)     # Read repository structure from the default source path.
     modules: 'PSRule.Rules.Azure'            # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
     outputFormat: NUnit3                     # Save results to an NUnit report.
@@ -147,11 +146,9 @@ Run analysis of files within `out/` and all subdirectories using the named basel
 
 ```yaml
 steps:
-- task: ps-rule-assert@1
+- task: ps-rule-assert@2
   inputs:
-    inputType: inputPath
     inputPath: 'out/'              # Read objects from files in 'out/'.
     modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
     baseline: 'Azure.GA_2021_12'   # Use the 'Azure.GA_2021_12' baseline included within PSRule.Rules.Azure.
-    source: '.ps-rule/'            # Additionally, analyze object using custom rules from '.ps-rule/'.
 ```


### PR DESCRIPTION
## PR Summary

What's changed since v1.5.0:

- New features:
  - Added tasks for PSRule v2 support by @BernieWhite.
    [#312](https://github.com/microsoft/PSRule-pipelines/issues/312)
    - Added `ps-rule-assert@2` task.
    - Added `ps-rule-install@2` task.
  - Added support for outputting analysis results as SARIF by @BernieWhite.
    [#315](https://github.com/microsoft/PSRule-pipelines/issues/315)
    - To use the SARIF output format set the `outputFormat` parameter to `Sarif`.
    - Currently a pre-release version of PSRule must be used.
  - Added the ability to use a specific version of PSRule by @BernieWhite.
    [#314](https://github.com/microsoft/PSRule-pipelines/issues/314)
    - To install a specific version set the version parameter.
    - By default, the latest stable version of PSRule is used.
  - Added the ability to use an alternative PowerShell repository by @BernieWhite.
    [#353](https://github.com/microsoft/PSRule-pipelines/issues/353)
    - Register and authenticate to the repository in PowerShell if required.
    - Configure repository to install modules from the named repository.
- General improvements:
  - Expose more rule error output in CI by @ArmaanMcleod.
    [#308](https://github.com/microsoft/PSRule-pipelines/issues/308)
- Engineering:
  - Flagged v0 tasks as deprecated by @BernieWhite.
    [#399](https://github.com/microsoft/PSRule-pipelines/issues/399)
- Bug fixes:
  - Fixed failure loading VstsTaskSdk by @BernieWhite.
    [#361](https://github.com/microsoft/PSRule-pipelines/issues/361)
  - Fixed handling of unset path by @BernieWhite.
    [#363](https://github.com/microsoft/PSRule-pipelines/issues/363)
  - Fixed dependency conflict with older module versions by @BernieWhite.
    [#396](https://github.com/microsoft/PSRule-pipelines/issues/396)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
