### PR TITLE
Added support for alternative option file #349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since v2.0.1:
 
+- New features:
+  - Added support for alternative option file.
+    [#349](https://github.com/microsoft/PSRule-pipelines/issues/349)
+    - Set the option parameter to the path to an options file.
+    - By default, the ps-rule.yaml option file is used.
 - Engineering:
   - Bump azure-pipelines-task-lib to v3.3.1.
     [#418](https://github.com/microsoft/PSRule-pipelines/pull/418)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -56,9 +56,10 @@ steps:
     inputType: repository, inputPath                        # Required. Determines the type of input to use for PSRule.
     inputPath: string                                       # Required. The path PSRule will look for files to validate.
     modules: string                                         # Optional. A comma separated list of modules to use for analysis.
+    source: string                                          # Optional. An path containing rules to use for analysis.
     baseline: string                                        # Optional. The name of a PSRule baseline to use.
     conventions: string                                     # Optional. A comma separated list of conventions to use.
-    source: string                                          # Optional. An path containing rules to use for analysis.
+    option: string                                          # Optional. The path to an options file.
     outputFormat: None, Yaml, Json, Markdown, NUnit3, Csv   # Optional. The format to use when writing results to disk.
     outputPath: string                                      # Optional. The file path to write results to.
     path: string                                            # Optional. The working directory PSRule is run from.
@@ -80,6 +81,9 @@ steps:
   If the modules have not been installed,
   the latest stable version will be installed from the PowerShell Gallery automatically.
   For example: _PSRule.Rules.Azure,PSRule.Rules.Kubernetes_
+- **source**: An path containing rules to use for analysis.
+  Use this option to include rules not installed as a PowerShell module.
+  This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
 - **baseline**: The name of a PSRule baseline to use.
   Baselines can be used from modules or specified in a separate file.
   To use a baseline included in a module use `modules:` with `baseline:`.
@@ -87,9 +91,9 @@ steps:
 - **conventions**: A comma separated list of conventions to use.
   Conventions can be used from modules or specified in a separate file.
   For example: _Monitor.LogAnalytics.Import_
-- **source**: An path containing rules to use for analysis.
-  Use this option to include rules not installed as a PowerShell module.
-  This binds to the [-Path](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Assert-PSRule.html#-path) parameter.
+- **option**: The path to an options file.
+  By default, `ps-rule.yaml` will be used if it exists.
+  Configure this parameter to use a different file.
 - **outputFormat**: Output results can be written to disk in addition to the default output.
   Use this option to determine the format to write results.
   By default, results are not written to disk.

--- a/tasks/ps-rule-assertV2/powershell.ps1
+++ b/tasks/ps-rule-assertV2/powershell.ps1
@@ -34,9 +34,13 @@ param (
     [Parameter(Mandatory = $False)]
     [String]$Baseline = (Get-VstsInput -Name 'baseline'),
 
-    # The conventions to use
+    # A comma separated list of conventions to use.
     [Parameter(Mandatory = $False)]
     [String]$Conventions = (Get-VstsInput -Name 'conventions'),
+
+    # The path to an options file.
+    [Parameter(Mandatory = $False)]
+    [String]$Option = (Get-VstsInput -Name 'option'),
 
     # The output format
     [Parameter(Mandatory = $False)]
@@ -254,6 +258,7 @@ Write-Host "[info] Using Baseline: $Baseline";
 Write-Host "[info] Using Conventions: $Conventions";
 Write-Host "[info] Using InputType: $InputType";
 Write-Host "[info] Using InputPath: $InputPath";
+Write-Host "[info] Using Option: $Option";
 Write-Host "[info] Using OutputFormat: $OutputFormat";
 Write-Host "[info] Using OutputPath: $OutputPath";
 
@@ -275,6 +280,10 @@ try {
     if ($Conventions.Length -gt 0) {
         $invokeParams['Convention'] = $Conventions;
         WriteDebug ([String]::Concat('-Convention ', [String]::Join(', ', $Conventions)));
+    }
+    if (![String]::IsNullOrEmpty($Option)) {
+        $invokeParams['Option'] = $Option;
+        WriteDebug ([String]::Concat('-Option ', $Option));
     }
     if (![String]::IsNullOrEmpty($Modules)) {
         $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);

--- a/tasks/ps-rule-assertV2/powershell.ts
+++ b/tasks/ps-rule-assertV2/powershell.ts
@@ -21,6 +21,7 @@ async function run() {
         let input_modules: string = task.getInput('modules', /*required*/ false);
         let input_baseline: string = task.getInput('baseline', /*required*/ false);
         let input_conventions: string = task.getInput('conventions', /*required*/ false);
+        let input_option: string = task.getInput('option', /*required*/ false);
         let input_outputFormat: string = task.getPathInput('outputFormat', /*required*/ false, /*check*/ false) || 'None';
         let input_outputPath: string = task.getPathInput('outputPath', /*required*/ false, /*check*/ false);
         let input_prerelease: boolean = task.getBoolInput('prerelease', /*required*/ false);
@@ -48,6 +49,9 @@ async function run() {
         }
         if (input_conventions !== undefined) {
             contents.push(`$scriptParams['Conventions'] = '${input_conventions}'`);
+        }
+        if (input_option !== undefined) {
+            contents.push(`$scriptParams['Option'] = '${input_option}'`);
         }
         if (input_outputFormat !== undefined) {
             contents.push(`$scriptParams['OutputFormat'] = '${input_outputFormat}'`);

--- a/tasks/ps-rule-assertV2/task.json
+++ b/tasks/ps-rule-assertV2/task.json
@@ -93,6 +93,14 @@
             "helpMarkDown": "A comma separated list of conventions to use."
         },
         {
+            "name": "option",
+            "type": "string",
+            "label": "Option",
+            "required": false,
+            "defaultValue": "",
+            "helpMarkDown": "The path to an options file."
+        },
+        {
             "name": "outputFormat",
             "type": "pickList",
             "label": "Output format",


### PR DESCRIPTION
## PR Summary

- Added support for alternative option file.
  - Set the option parameter to the path to an options file.
  - By default, the ps-rule.yaml option file is used.

Fixes #349 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
