### PR TITLE
Release v2.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Capture any error messages.
 **Task in use and version:**
 
 - Task: ps-rule-assert
-- Version: **[e.g. 1.5.0]**
+- Version: **[e.g. 2.1.0]**
 
 **Additional context**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.1.0
+
 What's changed since v2.0.1:
 
 - New features:
-  - Added support for alternative option file.
+  - Added support for alternative option file by @BernieWhite.
     [#349](https://github.com/microsoft/PSRule-pipelines/issues/349)
     - Set the option parameter to the path to an options file.
     - By default, the ps-rule.yaml option file is used.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -6,7 +6,7 @@ This document contains notes to help upgrade from previous versions of the PSRul
 
 Follow these notes to upgrade from previous versions to v1.5.0.
 
-### Node 10 exension handler
+### Node 10 extension handler
 
 Prior to v1.5.0, the Node 6 extension handler was used.
 From _March 31st 2022_ the Node 6 extension handler will be removed from Azure DevOps.


### PR DESCRIPTION
## PR Summary

What's changed since v2.0.1:

- New features:
  - Added support for alternative option file by @BernieWhite.
    [#349](https://github.com/microsoft/PSRule-pipelines/issues/349)
    - Set the option parameter to the path to an options file.
    - By default, the `ps-rule.yaml` option file is used.
- Engineering:
  - Bump azure-pipelines-task-lib to v3.3.1.
    [#418](https://github.com/microsoft/PSRule-pipelines/pull/418)
  - Bump PSRule to v2.1.0.
    [#446](https://github.com/microsoft/PSRule-pipelines/pull/446)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
