### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.3.0
+
+What's changed since v2.2.0:
+
 - Engineering:
   - Bump PSRule to v2.3.2.
     [#498](https://github.com/microsoft/PSRule-pipelines/pull/498)
     - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v232)
+  - Bump typescript to v4.8.2.
+    [#514](https://github.com/microsoft/PSRule-pipelines/pull/514)
 
 ## v2.2.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v2.2.0:

- Engineering:
  - Bump PSRule to v2.3.2.
    [#498](https://github.com/microsoft/PSRule-pipelines/pull/498)
    - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v232)
  - Bump typescript to v4.8.2.
    [#514](https://github.com/microsoft/PSRule-pipelines/pull/514)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
