### PR TITLE
Release v2.4.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Capture any error messages.
 **Task in use and version:**
 
 - Task: ps-rule-assert
-- Version: **[e.g. 2.2.0]**
+- Version: **[e.g. 2.4.1]**
 
 **Additional context**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.4.1
+
 What's changed since v2.4.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.4.0:

- Engineering:
  - Bump PSRule to v2.4.1.
    [#548](https://github.com/microsoft/PSRule-pipelines/pull/548)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v241)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
