### PR TITLE
Release v2.5.1

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -2,12 +2,12 @@
 # CI pipeline for PSRule-pipelines
 
 variables:
-  version: '2.5.0'
+  version: '2.6.0'
   buildConfiguration: 'Release'
   publish: 'true'
   imageName: 'ubuntu-20.04'
 
-# Use build number format, i.e. 2.5.0-B2106001
+# Use build number format, i.e. 2.6.0-B2106001
 name: $(version)-B$(date:yyMM)$(rev:rrr)
 
 trigger:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Capture any error messages.
 **Task in use and version:**
 
 - Task: ps-rule-assert
-- Version: **[e.g. 2.4.1]**
+- Version: **[e.g. 2.5.1]**
 
 **Additional context**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.5.1
+
 What's changed since v2.5.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.5.0:

- Engineering:
  - Bump PSRule to v2.5.1.
    [#569](https://github.com/microsoft/PSRule-pipelines/pull/569)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v251)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
