### PR TITLE
Deprecated task versions 1 and 0 #694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 - Node 6 extension handler will be removed from Azure DevOps _March 31st 2022_.
   To ensure your pipelines continue to work, please upgrade to the latest versions of the tasks.
   See [upgrade notes][1] for more information.
+- Task versions `@0` and `@1` are deprecated and will be removed from _v3.0.0_.
+  To ensure your pipelines continue to work, please upgrade to the latest versions of the tasks.
+  See [upgrade notes][1] for more information.
 
   [1]: docs/upgrade-notes.md
 
@@ -14,6 +17,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since v2.7.0:
 
+- General improvements:
+  - **Important change**: Added warning to V1 tasks and update V0 tasks by @BernieWhite.
+    [#694](https://github.com/microsoft/PSRule-pipelines/issues/694)
+    - Deprecated task versions `@0` and `@1` will be removed from _v3.0.0_.
+    - Upgrade to `@2` task versions to ensure your pipelines continue to work.
 - Engineering:
   - Bump azure-pipelines-task-lib to v4.2.0.
     [#660](https://github.com/microsoft/PSRule-pipelines/pull/660)

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -2,6 +2,20 @@
 
 This document contains notes to help upgrade from previous versions of the PSRule extension.
 
+## Upgrade to v2.8.0
+
+Follow these notes to upgrade from previous versions to v2.8.0.
+
+### @2 task versions
+
+From PSRule _v2.8.0_ the `@1` and `@0` task versions are deprecated and will be removed from _v3.0.0_.
+The `@2` task versions are now the default task versions.
+
+To upgrade to the latest task versions to use `@2` or higher.
+
+- `ps-rule-install@2` instead of `ps-rule-install@1`.
+- `ps-rule-assert@2` instead of `ps-rule-assert@1`.
+
 ## Upgrade to v1.5.0
 
 Follow these notes to upgrade from previous versions to v1.5.0.

--- a/tasks/ps-rule-assertV0/powershell.ps1
+++ b/tasks/ps-rule-assertV0/powershell.ps1
@@ -48,7 +48,7 @@ param (
     [String]$OutputPath = (Get-VstsInput -Name 'outputPath')
 )
 
-Write-Host "`#`#vso[task.logissue type=warning]You are using an old version of this task that uses a deprecated version of Node. Please upgrade to the latest version by using 'ps-rule-assert@1'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
+Write-Host "`#`#vso[task.logissue type=warning]You are using an old version of this task that uses a deprecated version of Node. Please upgrade to the latest version by using 'ps-rule-assert@2'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
 
 if ($Env:SYSTEM_DEBUG -eq 'true') {
     $VerbosePreference = 'Continue';

--- a/tasks/ps-rule-assertV1/powershell.ps1
+++ b/tasks/ps-rule-assertV1/powershell.ps1
@@ -48,6 +48,8 @@ param (
     [String]$OutputPath = (Get-VstsInput -Name 'outputPath')
 )
 
+Write-Host "`#`#vso[task.logissue type=warning]This version of the task is deprecated. Please upgrade to the latest version by using 'ps-rule-assert@2'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
+
 if ($Env:SYSTEM_DEBUG -eq 'true') {
     $VerbosePreference = 'Continue';
 }

--- a/tasks/ps-rule-installV0/powershell.ps1
+++ b/tasks/ps-rule-installV0/powershell.ps1
@@ -22,7 +22,7 @@ param (
     [System.Boolean]$PreRelease = (Get-VstsInput -Name 'prerelease' -AsBool)
 )
 
-Write-Host "`#`#vso[task.logissue type=warning]You are using an old version of this task that uses a deprecated version of Node. Please upgrade to the latest version by using 'ps-rule-install@1'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
+Write-Host "`#`#vso[task.logissue type=warning]You are using an old version of this task that uses a deprecated version of Node. Please upgrade to the latest version by using 'ps-rule-install@2'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
 
 if ($Env:SYSTEM_DEBUG -eq 'true') {
     $VerbosePreference = 'Continue';

--- a/tasks/ps-rule-installV1/powershell.ps1
+++ b/tasks/ps-rule-installV1/powershell.ps1
@@ -22,6 +22,8 @@ param (
     [System.Boolean]$PreRelease = (Get-VstsInput -Name 'prerelease' -AsBool)
 )
 
+Write-Host "`#`#vso[task.logissue type=warning]This version of the task is deprecated. Please upgrade to the latest version by using 'ps-rule-install@2'. See https://aka.ms/ps-rule-pipelines/upgrade for details.";
+
 if ($Env:SYSTEM_DEBUG -eq 'true') {
     $VerbosePreference = 'Continue';
 }


### PR DESCRIPTION
## PR Summary

- Added warnings to `@0` and `@1` tasks to upgrade to `@2`.

Fixes #694 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
