### PR TITLE
Bump PowerShell dependencies

### DIFF
--- a/.azure-pipelines/jobs/release.yaml
+++ b/.azure-pipelines/jobs/release.yaml
@@ -58,7 +58,7 @@ jobs:
   - task: TfxInstaller@3
     displayName: 'Install tfx-cli'
     inputs:
-      version: 'v0.14.x'
+      version: 'v0.16.x'
 
   # Download extension
   - task: DownloadPipelineArtifact@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ What's changed since v2.9.0:
 
 - Engineering:
   - Bump VstsTaskSdk to v0.17.0.
+    [#922](https://github.com/microsoft/PSRule-pipelines/pull/922)
   - Bump azure-pipelines-task-lib to v4.7.0.
     [#907](https://github.com/microsoft/PSRule-pipelines/pull/907)
   - Bump typescript to v5.3.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since v2.9.0:
 
 - Engineering:
+  - Bump VstsTaskSdk to v0.17.0.
   - Bump azure-pipelines-task-lib to v4.7.0.
     [#907](https://github.com/microsoft/PSRule-pipelines/pull/907)
   - Bump typescript to v5.3.2.

--- a/extension.config.js
+++ b/extension.config.js
@@ -75,7 +75,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-assert/ps-rule-assertV0/ps_modules/PSRule/1.11.1"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-assert/ps-rule-assertV0/ps_modules/VstsTaskSdk"
       },
       {
@@ -87,7 +87,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-install/ps-rule-installV0/ps_modules/PackageManagement"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-install/ps-rule-installV0/ps_modules/VstsTaskSdk"
       },
       {
@@ -95,7 +95,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-assert/ps-rule-assertV1/ps_modules/PSRule/1.11.1"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-assert/ps-rule-assertV1/ps_modules/VstsTaskSdk"
       },
       {
@@ -107,7 +107,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-install/ps-rule-installV1/ps_modules/PackageManagement"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-install/ps-rule-installV1/ps_modules/VstsTaskSdk"
       },
       {
@@ -123,7 +123,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-assert/ps-rule-assertV2/ps_modules/PSRule/2.9.0"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-assert/ps-rule-assertV2/ps_modules/VstsTaskSdk"
       },
       {
@@ -135,7 +135,7 @@ module.exports = (env) => {
         packagePath: "/ps-rule-install/ps-rule-installV2/ps_modules/PackageManagement"
       },
       {
-        path: "out/dist/ps_modules/VstsTaskSdk/0.11.0",
+        path: "out/dist/ps_modules/VstsTaskSdk/0.17.0",
         packagePath: "/ps-rule-install/ps-rule-installV2/ps_modules/VstsTaskSdk"
       }
     ],

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
       "version": "2.9.0"
     },
     "VstsTaskSdk": {
-      "version": "0.11.0"
+      "version": "0.17.0"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## PR Summary

- Bump VstsTaskSdk to v0.17.0.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule-pipelines/blob/main/CHANGELOG.md) has been updated with change under unreleased section
